### PR TITLE
Add basic game loop and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,13 @@
 </head>
 <body>
     <canvas id="myCanvas"></canvas>
+    <div id="info">
+        <p id="turn-info"></p>
+        <p id="scores"></p>
+    </div>
     <div id="player1-hand" class="hand"></div>
     <div id="player2-hand" class="hand"></div>
-    <div id="player3-hand" class="hand"></div>
-    <div id="player4-hand" class="hand"></div>
+    <div id="discard-pile" class="hand"></div>
     <div style="display:none;">
         <img id="imgdeck" src="images/back.png" width="25" height="32" />
     </div>

--- a/main.js
+++ b/main.js
@@ -1,46 +1,113 @@
-var canvas = document.getElementById("myCanvas");
-var ctx = canvas.getContext("2d");
-var imgdeck = document.getElementById("imgdeck");
+// Main game logic and UI management
+
+const canvas = document.getElementById('myCanvas');
+const ctx = canvas.getContext('2d');
+const imgdeck = document.getElementById('imgdeck');
 
 canvas.width = 600;
 canvas.height = 600;
 
-
-ctx.fillStyle = "green";
-ctx.fillRect(0,0,canvas.width,canvas.height);
-ctx.drawImage(imgdeck, 335,275,50,64);
+ctx.fillStyle = 'green';
+ctx.fillRect(0, 0, canvas.width, canvas.height);
+ctx.drawImage(imgdeck, 335, 275, 50, 64);
 
 const deck = new Deck();
 const discards = [];
 
-const players = [{name: 'Human', hand: []}, new AIPlayer('Computer')];
+const players = [{ name: 'Human', hand: [], score: 0 }, new AIPlayer('Computer')];
 let currentPlayer = 0;
 
-function nextTurn() {
-    currentPlayer = (currentPlayer + 1) % players.length;
-    const player = players[currentPlayer];
-    if (player instanceof AIPlayer) {
-        player.takeTurn(deck, discards);
-        updateUI();
-        nextTurn();
+function dealInitialCards() {
+    for (let i = 0; i < 7; i++) {
+        players.forEach(p => {
+            const c = deck.draw();
+            if (c) p.hand.push(c);
+        });
+    }
+}
+
+function renderHands() {
+    players.forEach((player, idx) => {
+        const handDiv = document.getElementById(`player${idx + 1}-hand`);
+        handDiv.innerHTML = '';
+        player.hand.forEach((card, cidx) => {
+            const img = document.createElement('img');
+            img.src = card.image.src;
+            img.width = card.width;
+            img.height = card.height;
+            if (idx === 0) {
+                img.style.cursor = 'pointer';
+                img.addEventListener('click', () => discardCard(cidx));
+            }
+            handDiv.appendChild(img);
+        });
+    });
+
+    const discardDiv = document.getElementById('discard-pile');
+    discardDiv.innerHTML = '';
+    if (discards.length > 0) {
+        const card = discards[discards.length - 1];
+        const img = document.createElement('img');
+        img.src = card.image.src;
+        discardDiv.appendChild(img);
     }
 }
 
 function updateUI() {
-    console.log('Discards:', discards.map(c => c.value + c.suit).join(','));
+    document.getElementById('turn-info').textContent = `Turn: ${players[currentPlayer].name}`;
+    const scores = players.map(p => `${p.name}: ${p.hand.length}`).join(' | ');
+    document.getElementById('scores').textContent = scores;
 }
 
-const drw = document.getElementById('draw');
-console.log(drw);
-drw.addEventListener("click", ()=>{
+function nextTurn() {
+    currentPlayer = (currentPlayer + 1) % players.length;
+    updateUI();
+    if (players[currentPlayer] instanceof AIPlayer) {
+        setTimeout(() => {
+            const discard = players[currentPlayer].takeTurn(deck, discards);
+            renderHands();
+            updateUI();
+            nextTurn();
+        }, 500);
+    }
+}
+
+function discardCard(index) {
+    if (currentPlayer !== 0) return;
+    const player = players[currentPlayer];
+    const [card] = player.hand.splice(index, 1);
+    if (card) discards.push(card);
+    renderHands();
+    updateUI();
+    nextTurn();
+}
+
+function playerDraw() {
+    if (currentPlayer !== 0) return;
     const card = deck.draw();
     if (!card) return;
-    const img = document.createElement('img');
-    img.src = card.image.src;
-    img.width = card.width;
-    img.height = card.height;
-    const player = players[currentPlayer];
-    player.hand.push(card);
-    const hand = document.getElementById(`player${currentPlayer + 1}-hand`);
-    hand.appendChild(img);
-});
+    players[0].hand.push(card);
+    renderHands();
+    updateUI();
+}
+
+function drawFromDiscard() {
+    if (currentPlayer !== 0) return;
+    const card = discards.pop();
+    if (!card) return;
+    players[0].hand.push(card);
+    renderHands();
+    updateUI();
+}
+
+// Button bindings
+const drw = document.getElementById('draw');
+drw.addEventListener('click', playerDraw);
+const drwDisc = document.getElementById('drawdisc');
+drwDisc.addEventListener('click', drawFromDiscard);
+
+// Initialise game
+dealInitialCards();
+renderHands();
+updateUI();
+

--- a/style.css
+++ b/style.css
@@ -101,3 +101,19 @@ button {
     width: 50px;
     height: 64px;
 }
+
+#info{
+    color: var(--white);
+    font-weight: 600;
+    margin: 10px;
+}
+
+#discard-pile {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+}
+#discard-pile img {
+    width: 50px;
+    height: 64px;
+}


### PR DESCRIPTION
## Summary
- add scoreboard, turn info, and discard pile to the page
- style the new areas
- implement a playable loop in `main.js` with AI turns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff68abe848332bb81bf83299aa2eb